### PR TITLE
Zero out PV and GSP yield when no system exists

### DIFF
--- a/nowcasting_dataloader/datasets.py
+++ b/nowcasting_dataloader/datasets.py
@@ -352,7 +352,6 @@ class SatFlowDataset(NetCDFDataset):
         """
         Adds encodings to the targets and inputs
 
-
         Args:
             x: Dictionary containing model inputs
             key: Key to check and insert

--- a/nowcasting_dataloader/datasets.py
+++ b/nowcasting_dataloader/datasets.py
@@ -394,10 +394,8 @@ class SatFlowDataset(NetCDFDataset):
 
         for key in [PV_YIELD, GSP_YIELD]:
             if key in x:
-                print(key)  # Batch, channels, timesteps, [ID]
-                print(x[key].shape)
-                mask = torch.isnan(x[key][:, 0, 0, :])  # Only looking at the yield
-                mask = einops.repeat(mask, "b id -> b c t id", c=x[key].shape[1], t=x[key].shape[2])
+                mask = torch.isnan(x[key][:, 0, :])  # Only looking at the yield
+                mask = einops.repeat(mask, "b id -> b t id", t=x[key].shape[1])
                 # Zero out for all entries related to
                 x[key][mask] = 0.0
 

--- a/nowcasting_dataloader/datasets.py
+++ b/nowcasting_dataloader/datasets.py
@@ -352,8 +352,6 @@ class SatFlowDataset(NetCDFDataset):
         """
         Adds encodings to the targets and inputs
 
-        Also checks for any NaN values in the data, to zero out the position encodings for that
-        value. Primarily for PV and GSP systems where there is filler data
 
         Args:
             x: Dictionary containing model inputs

--- a/nowcasting_dataloader/datasets.py
+++ b/nowcasting_dataloader/datasets.py
@@ -375,7 +375,6 @@ class SatFlowDataset(NetCDFDataset):
                 x[key + "_query"] = future_encoding
         return x
 
-
     def zero_out_nan_pv_systems(self, x: dict) -> dict:
         """
         Zeros out NaN PV systems and their position encodings
@@ -395,10 +394,10 @@ class SatFlowDataset(NetCDFDataset):
 
         for key in [PV_YIELD, GSP_YIELD]:
             if key in x:
-                print(key) # Batch, channels, timesteps, [ID]
+                print(key)  # Batch, channels, timesteps, [ID]
                 print(x[key].shape)
-                mask = torch.isnan(x[key][:,0,0,:]) # Only looking at the yield
-                mask = einops.repeat(mask, 'b id -> b c t id', c=x[key].shape[1], t=x[key].shape[2])
+                mask = torch.isnan(x[key][:, 0, 0, :])  # Only looking at the yield
+                mask = einops.repeat(mask, "b id -> b c t id", c=x[key].shape[1], t=x[key].shape[2])
                 # Zero out for all entries related to
                 x[key][mask] = 0.0
 

--- a/tests/test_satflow_dataset.py
+++ b/tests/test_satflow_dataset.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import torch
 from nowcasting_dataset.config.model import Configuration, InputData
 from nowcasting_dataset.dataset.batch import Batch
+from nowcasting_dataloader.batch import BatchML
 
 from nowcasting_dataloader.datasets import SatFlowDataset, worker_init_fn
 
@@ -145,3 +146,36 @@ def test_satflow_dataset_local_using_configuration_with_position_encoding():
             assert type(y[k]) == torch.Tensor
         # Make sure file isn't deleted!
         assert os.path.exists(os.path.join(DATA_PATH, "nwp/000000.nc"))
+
+def test_zero_pv_systems():
+    c = Configuration()
+    c.input_data = InputData.set_all_to_defaults()
+    c.process.batch_size = 4
+    c.input_data.satellite.satellite_image_size_pixels = 24
+    configuration = c
+    batch = Batch.fake(configuration = c)
+    x = BatchML.from_batch(batch)
+    x = x.dict()
+    x["pv"]["pv_yield"][0,:,100:] = float("nan")
+    x["pv"]["pv_yield"][2,:,64:] = float("nan")
+    x["gsp"]["gsp_yield"][0,:,30:] = float("nan")
+    x["gsp"]["gsp_yield"][3,:,15:] = float("nan")
+    x["pv_yield"] = x["pv"]["pv_yield"]
+    x["gsp_yield"] = x["gsp"]["gsp_yield"]
+    dset = SatFlowDataset(
+        1,
+        ".",
+        ".",
+        cloud="local",
+        history_minutes=10,
+        forecast_minutes=10,
+        configuration=configuration,
+        add_position_encoding=True,
+        add_hrv_satellite_target=True,
+        add_satellite_target=True,
+        )
+    cleaned = dset.zero_out_nan_pv_systems(x)
+    assert torch.isnan(x["pv_yield"]).sum() == 0
+    assert torch.isnan(x["gsp_yield"]).sum() == 0
+    assert torch.isclose(torch.sum(x["gsp_yield"][0,:,30:]), torch.zeros(1))
+    assert not torch.isclose(torch.sum(x["gsp_yield"][1,:,30:]), torch.zeros(1))

--- a/tests/test_satflow_dataset.py
+++ b/tests/test_satflow_dataset.py
@@ -175,7 +175,7 @@ def test_zero_pv_systems():
         add_satellite_target=True,
         )
     cleaned = dset.zero_out_nan_pv_systems(x)
-    assert torch.isnan(x["pv_yield"]).sum() == 0
-    assert torch.isnan(x["gsp_yield"]).sum() == 0
-    assert torch.isclose(torch.sum(x["gsp_yield"][0,:,30:]), torch.zeros(1))
-    assert not torch.isclose(torch.sum(x["gsp_yield"][1,:,30:]), torch.zeros(1))
+    assert torch.isnan(cleaned["pv_yield"]).sum() == 0
+    assert torch.isnan(cleaned["gsp_yield"]).sum() == 0
+    assert torch.isclose(torch.sum(cleaned["gsp_yield"][0,:,30:]), torch.zeros(1))
+    assert not torch.isclose(torch.sum(cleaned["gsp_yield"][1,:,30:]), torch.zeros(1))

--- a/tests/test_satflow_dataset.py
+++ b/tests/test_satflow_dataset.py
@@ -178,5 +178,5 @@ def test_zero_pv_systems():
     cleaned = dset.zero_out_nan_pv_systems(x)
     assert torch.isnan(cleaned["pv_yield"]).sum() == 0
     assert torch.isnan(cleaned["gsp_yield"]).sum() == 0
-    assert torch.isclose(torch.sum(cleaned["gsp_yield"][0,:,30:]), torch.zeros(1))
-    assert not torch.isclose(torch.sum(cleaned["gsp_yield"][1,:,30:]), torch.zeros(1))
+    assert torch.isclose(torch.sum(cleaned["gsp_yield"][0, :, 30:]), torch.zeros(1))
+    assert not torch.isclose(torch.sum(cleaned["gsp_yield"][1, :, 30:]), torch.zeros(1))


### PR DESCRIPTION
# Pull Request

## Description

Zeros out the position encoding and NaN values for non-existent PV and GSP systems

Fixes #

## How Has This Been Tested?

Unit tests

- [ ] No
- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
