### PR TITLE
Add only loading partial NetCDF batches

### DIFF
--- a/nowcasting_dataloader/batch.py
+++ b/nowcasting_dataloader/batch.py
@@ -164,4 +164,5 @@ class BatchML(Example):
 
         # loop over all data sources and normalize
         for data_sources in self.data_sources:
-            data_sources.normalize()
+            if data_sources is not None:
+                data_sources.normalize()

--- a/nowcasting_dataloader/datasets.py
+++ b/nowcasting_dataloader/datasets.py
@@ -279,7 +279,10 @@ class SatFlowDataset(NetCDFDataset):
         if "nwp" in self.data_sources_names and len(batch["nwp"].get("data", [])) > 0:
             # We can give future NWP too, as that will be available
             x[NWP_DATA] = batch["nwp"]["data"]
-        if "topographic" in self.data_sources_names and len(batch["topographic"].get(TOPOGRAPHIC_DATA, [])) > 0:
+        if (
+            "topographic" in self.data_sources_names
+            and len(batch["topographic"].get(TOPOGRAPHIC_DATA, [])) > 0
+        ):
             # Need to expand dims to get a single channel one
             # Results in topographic maps with [Batch, Channel, H, W]
             x[TOPOGRAPHIC_DATA] = torch.unsqueeze(
@@ -327,8 +330,10 @@ class SatFlowDataset(NetCDFDataset):
                     [x[NWP_DATA], batch[NWP_DATA + "_position_encoding"]], dim=1
                 )
             if len(x.get(PV_YIELD, [])) > 0:
-                past_encoding = batch["pv_position_encoding"][:, :, :self.current_timestep_index]
-                x[PV_YIELD] = einops.rearrange(torch.cat([x[PV_YIELD], past_encoding], dim=1), 'b c id t -> b c t id')
+                past_encoding = batch["pv_position_encoding"][:, :, : self.current_timestep_index]
+                x[PV_YIELD] = einops.rearrange(
+                    torch.cat([x[PV_YIELD], past_encoding], dim=1), "b c id t -> b c t id"
+                )
             # Add the future GSP position encoding for querying
             x[GSP_YIELD + "_query"] = batch["gsp_position_encoding"][
                 :, :, self.current_timestep_index_30 :

--- a/nowcasting_dataloader/datasets.py
+++ b/nowcasting_dataloader/datasets.py
@@ -48,7 +48,7 @@ class NetCDFDataset(torch.utils.data.Dataset):
         forecast_minutes: Optional[int] = None,
         normalize: bool = True,
         add_position_encoding: bool = False,
-            data_source_names: Optional[list[str]] = None
+        data_source_names: Optional[list[str]] = None,
     ):
         """
         Netcdf Dataset
@@ -153,7 +153,9 @@ class NetCDFDataset(torch.utils.data.Dataset):
         else:
             local_netcdf_folder = self.src_path
 
-        batch: Batch = Batch.load_netcdf(local_netcdf_folder, batch_idx=batch_idx, data_sources_names = self.data_source_names)
+        batch: Batch = Batch.load_netcdf(
+            local_netcdf_folder, batch_idx=batch_idx, data_sources_names=self.data_source_names
+        )
 
         if self.select_subset_data:
             batch = subselect_data(
@@ -199,7 +201,7 @@ class SatFlowDataset(NetCDFDataset):
         add_position_encoding: bool = False,
         add_satellite_target: bool = False,
         add_hrv_satellite_target: bool = False,
-            data_source_names: Optional[list[str]] = None
+        data_source_names: Optional[list[str]] = None,
     ):
         """
         Netcdf Dataset
@@ -235,7 +237,7 @@ class SatFlowDataset(NetCDFDataset):
             forecast_minutes=forecast_minutes,
             normalize=normalize,
             add_position_encoding=add_position_encoding,
-            data_source_names = data_source_names
+            data_source_names=data_source_names,
         )
 
         self.add_satellite_target = add_satellite_target

--- a/nowcasting_dataloader/datasets.py
+++ b/nowcasting_dataloader/datasets.py
@@ -48,6 +48,7 @@ class NetCDFDataset(torch.utils.data.Dataset):
         forecast_minutes: Optional[int] = None,
         normalize: bool = True,
         add_position_encoding: bool = False,
+            data_source_names: Optional[list[str]] = None
     ):
         """
         Netcdf Dataset
@@ -68,6 +69,7 @@ class NetCDFDataset(torch.utils.data.Dataset):
             cloud: which cloud is used, can be "gcp", "aws" or "local".
             normalize: normalize the batch data
             add_position_encoding: Whether to add position encoding or not
+            data_source_names: Names of data sources to load, if not using all of them
         """
         self.n_batches = n_batches
         self.src_path = src_path
@@ -78,6 +80,7 @@ class NetCDFDataset(torch.utils.data.Dataset):
         self.configuration = configuration
         self.normalize = normalize
         self.add_position_encoding = add_position_encoding
+        self.data_source_names = data_source_names
 
         logger.info(f"Setting up NetCDFDataset for {src_path}")
 
@@ -150,7 +153,7 @@ class NetCDFDataset(torch.utils.data.Dataset):
         else:
             local_netcdf_folder = self.src_path
 
-        batch: Batch = Batch.load_netcdf(local_netcdf_folder, batch_idx=batch_idx)
+        batch: Batch = Batch.load_netcdf(local_netcdf_folder, batch_idx=batch_idx, data_sources_names = self.data_source_names)
 
         if self.select_subset_data:
             batch = subselect_data(
@@ -196,6 +199,7 @@ class SatFlowDataset(NetCDFDataset):
         add_position_encoding: bool = False,
         add_satellite_target: bool = False,
         add_hrv_satellite_target: bool = False,
+            data_source_names: Optional[list[str]] = None
     ):
         """
         Netcdf Dataset
@@ -218,6 +222,7 @@ class SatFlowDataset(NetCDFDataset):
             add_position_encoding: Whether to add position encoding or not
             add_satellite_target: Whether to add future satellite imagery to the target or not
             add_hrv_satellite_target: Whether to add future HRV satellite imagery to the target
+            data_source_names: Names of data sources to load, if not using all of them
         """
         super().__init__(
             n_batches=n_batches,
@@ -230,6 +235,7 @@ class SatFlowDataset(NetCDFDataset):
             forecast_minutes=forecast_minutes,
             normalize=normalize,
             add_position_encoding=add_position_encoding,
+            data_source_names = data_source_names
         )
 
         self.add_satellite_target = add_satellite_target
@@ -326,8 +332,10 @@ class SatFlowDataset(NetCDFDataset):
             ]
 
         # Rename to match other ones better
-        x[SATELLITE_DATA] = x.pop("satellite")
-        x["hrv_" + SATELLITE_DATA] = x.pop("hrvsatellite")
+        if len(x.get("satellite", [])) > 0:
+            x[SATELLITE_DATA] = x.pop("satellite")
+        if len(x.get("hrvsatellite", [])) > 0:
+            x["hrv_" + SATELLITE_DATA] = x.pop("hrvsatellite")
 
         # Zero out NaN PV and GSP Yield
         x = self.zero_out_nan_pv_systems(x)

--- a/nowcasting_dataloader/datasets.py
+++ b/nowcasting_dataloader/datasets.py
@@ -18,7 +18,7 @@ from nowcasting_dataset.consts import (
     SATELLITE_DATA,
     TOPOGRAPHIC_DATA,
 )
-from nowcasting_dataset.dataset.batch import Batch
+from nowcasting_dataset.dataset.batch import Batch, Example
 from nowcasting_dataset.filesystem.utils import delete_all_files_in_temp_path, download_to_local
 from nowcasting_dataset.utils import set_fsspec_for_multiprocess
 
@@ -80,6 +80,8 @@ class NetCDFDataset(torch.utils.data.Dataset):
         self.configuration = configuration
         self.normalize = normalize
         self.add_position_encoding = add_position_encoding
+        if data_sources_names is None:
+            data_sources_names = list(Example.__fields__.keys())
         self.data_sources_names = data_sources_names
 
         logger.info(f"Setting up NetCDFDataset for {src_path}")

--- a/nowcasting_dataloader/datasets.py
+++ b/nowcasting_dataloader/datasets.py
@@ -272,7 +272,7 @@ class SatFlowDataset(NetCDFDataset):
             x["hrvsatellite"] = past_hrv_satellite_data
         if "pv" in self.data_sources_names and len(batch["pv"].get(PV_YIELD, [])) > 0:
             past_pv_data = torch.unsqueeze(
-                batch["pv"][PV_YIELD][:, :, : self.current_timestep_index], dim=1
+                batch["pv"][PV_YIELD][:, : self.current_timestep_index], dim=1
             )
             x[PV_YIELD] = past_pv_data
             x[PV_SYSTEM_ID] = torch.nan_to_num(batch["pv"][PV_SYSTEM_ID])
@@ -331,9 +331,7 @@ class SatFlowDataset(NetCDFDataset):
                 )
             if len(x.get(PV_YIELD, [])) > 0:
                 past_encoding = batch["pv_position_encoding"][:, :, : self.current_timestep_index]
-                x[PV_YIELD] = einops.rearrange(
-                    torch.cat([x[PV_YIELD], past_encoding], dim=1), "b c id t -> b c t id"
-                )
+                x[PV_YIELD] = torch.cat([x[PV_YIELD], past_encoding], dim=1)
             # Add the future GSP position encoding for querying
             x[GSP_YIELD + "_query"] = batch["gsp_position_encoding"][
                 :, :, self.current_timestep_index_30 :

--- a/nowcasting_dataloader/datasets.py
+++ b/nowcasting_dataloader/datasets.py
@@ -48,7 +48,7 @@ class NetCDFDataset(torch.utils.data.Dataset):
         forecast_minutes: Optional[int] = None,
         normalize: bool = True,
         add_position_encoding: bool = False,
-        data_source_names: Optional[list[str]] = None,
+        data_sources_names: Optional[list[str]] = None,
     ):
         """
         Netcdf Dataset
@@ -69,7 +69,7 @@ class NetCDFDataset(torch.utils.data.Dataset):
             cloud: which cloud is used, can be "gcp", "aws" or "local".
             normalize: normalize the batch data
             add_position_encoding: Whether to add position encoding or not
-            data_source_names: Names of data sources to load, if not using all of them
+            data_sources_names: Names of data sources to load, if not using all of them
         """
         self.n_batches = n_batches
         self.src_path = src_path
@@ -80,7 +80,7 @@ class NetCDFDataset(torch.utils.data.Dataset):
         self.configuration = configuration
         self.normalize = normalize
         self.add_position_encoding = add_position_encoding
-        self.data_source_names = data_source_names
+        self.data_sources_names = data_sources_names
 
         logger.info(f"Setting up NetCDFDataset for {src_path}")
 
@@ -154,7 +154,7 @@ class NetCDFDataset(torch.utils.data.Dataset):
             local_netcdf_folder = self.src_path
 
         batch: Batch = Batch.load_netcdf(
-            local_netcdf_folder, batch_idx=batch_idx, data_sources_names=self.data_source_names
+            local_netcdf_folder, batch_idx=batch_idx, data_sources_names=self.data_sources_names
         )
 
         if self.select_subset_data:
@@ -201,7 +201,7 @@ class SatFlowDataset(NetCDFDataset):
         add_position_encoding: bool = False,
         add_satellite_target: bool = False,
         add_hrv_satellite_target: bool = False,
-        data_source_names: Optional[list[str]] = None,
+        data_sources_names: Optional[list[str]] = None,
     ):
         """
         Netcdf Dataset
@@ -224,7 +224,7 @@ class SatFlowDataset(NetCDFDataset):
             add_position_encoding: Whether to add position encoding or not
             add_satellite_target: Whether to add future satellite imagery to the target or not
             add_hrv_satellite_target: Whether to add future HRV satellite imagery to the target
-            data_source_names: Names of data sources to load, if not using all of them
+            data_sources_names: Names of data sources to load, if not using all of them
         """
         super().__init__(
             n_batches=n_batches,
@@ -237,7 +237,7 @@ class SatFlowDataset(NetCDFDataset):
             forecast_minutes=forecast_minutes,
             normalize=normalize,
             add_position_encoding=add_position_encoding,
-            data_source_names=data_source_names,
+            data_sources_names=data_sources_names,
         )
 
         self.add_satellite_target = add_satellite_target

--- a/nowcasting_dataloader/subset.py
+++ b/nowcasting_dataloader/subset.py
@@ -43,6 +43,10 @@ def subselect_data(
     else:
         if batch.satellite is not None:
             t0_dt_of_first_example = batch.satellite.time[0, current_timestep_index].values
+        elif batch.hrvsatellite is not None:
+            t0_dt_of_first_example = batch.hrvsatellite.time[0, current_timestep_index].values
+        elif batch.pv is not None:
+            t0_dt_of_first_example = batch.pv.time[0, current_timestep_index].values
         else:
             t0_dt_of_first_example = batch.nwp.time[0, current_timestep_index].values
 

--- a/tests/test_netcdf_dataset.py
+++ b/tests/test_netcdf_dataset.py
@@ -109,8 +109,8 @@ def test_netcdf_dataset_local_using_configuration_subset_of_data_sources():
             forecast_minutes=60,
             configuration=configuration,
             normalize=False,
-            data_sources_names = ["pv", "gsp", "hrvsatellite"]
-            )
+            data_sources_names=["pv", "gsp", "hrvsatellite"],
+        )
 
         dataloader_config = dict(
             pin_memory=True,

--- a/tests/test_netcdf_dataset.py
+++ b/tests/test_netcdf_dataset.py
@@ -109,8 +109,8 @@ def test_netcdf_dataset_local_using_configuration_subset_of_data_sources():
             forecast_minutes=60,
             configuration=configuration,
             normalize=False,
-            data_source_names=["pv", "gsp", "hrvsatellite"],
-        )
+            data_sources_names = ["pv", "gsp", "hrvsatellite"]
+            )
 
         dataloader_config = dict(
             pin_memory=True,
@@ -131,12 +131,13 @@ def test_netcdf_dataset_local_using_configuration_subset_of_data_sources():
 
         batch_ml = BatchML(**data)
 
-        assert batch_ml.nwp.data is None
-        assert batch_ml.topographic.topo_data is None
+        assert batch_ml.nwp is None
+        assert batch_ml.topographic is None
         assert batch_ml.pv.pv_yield.shape == (4, 19, 128)
         assert batch_ml.gsp.gsp_yield.shape == (4, 4, 32)
-        assert batch_ml.sun.sun_azimuth_angle.shape == (4, 19)
-        assert batch_ml.sun.sun_elevation_angle.shape == (4, 19)
+        assert batch_ml.sun is None
+        assert batch_ml.satellite is None
+        assert batch_ml.hrvsatellite is not None
 
         # Make sure file isn't deleted!
         assert os.path.exists(os.path.join(DATA_PATH, "nwp/000000.nc"))

--- a/tests/test_netcdf_dataset.py
+++ b/tests/test_netcdf_dataset.py
@@ -138,7 +138,7 @@ def test_netcdf_dataset_local_using_configuration_subset_of_data_sources():
         assert batch_ml.sun is None
         assert batch_ml.satellite is None
         assert batch_ml.hrvsatellite is not None
-        assert batch_ml.hrvsatellite.data.shape == (4, 5, 64, 64)
+        assert batch_ml.hrvsatellite.data.shape == (4, 1, 19, 192, 192)
 
         # Make sure file isn't deleted!
         assert os.path.exists(os.path.join(DATA_PATH, "nwp/000000.nc"))

--- a/tests/test_netcdf_dataset.py
+++ b/tests/test_netcdf_dataset.py
@@ -82,6 +82,7 @@ def test_netcdf_dataset_local_using_configuration():
         # Make sure file isn't deleted!
         assert os.path.exists(os.path.join(DATA_PATH, "nwp/000000.nc"))
 
+
 def test_netcdf_dataset_local_using_configuration_subset_of_data_sources():
     """Test netcdf locally"""
     c = Configuration()
@@ -108,8 +109,8 @@ def test_netcdf_dataset_local_using_configuration_subset_of_data_sources():
             forecast_minutes=60,
             configuration=configuration,
             normalize=False,
-            data_source_names = ["pv", "gsp", "hrvsatellite"]
-            )
+            data_source_names=["pv", "gsp", "hrvsatellite"],
+        )
 
         dataloader_config = dict(
             pin_memory=True,
@@ -120,7 +121,7 @@ def test_netcdf_dataset_local_using_configuration_subset_of_data_sources():
             # Disable automatic batching because dataset
             # returns complete batches.
             batch_size=None,
-            )
+        )
 
         _ = torch.utils.data.DataLoader(train_dataset, **dataloader_config)
 
@@ -139,6 +140,7 @@ def test_netcdf_dataset_local_using_configuration_subset_of_data_sources():
 
         # Make sure file isn't deleted!
         assert os.path.exists(os.path.join(DATA_PATH, "nwp/000000.nc"))
+
 
 @pytest.mark.skip("CD does not have access to GCS")
 def test_get_dataloaders_gcp(configuration: Configuration):

--- a/tests/test_netcdf_dataset.py
+++ b/tests/test_netcdf_dataset.py
@@ -138,6 +138,7 @@ def test_netcdf_dataset_local_using_configuration_subset_of_data_sources():
         assert batch_ml.sun is None
         assert batch_ml.satellite is None
         assert batch_ml.hrvsatellite is not None
+        assert batch_ml.hrvsatellite.data.shape == (4, 5, 64, 64)
 
         # Make sure file isn't deleted!
         assert os.path.exists(os.path.join(DATA_PATH, "nwp/000000.nc"))

--- a/tests/test_satflow_dataset.py
+++ b/tests/test_satflow_dataset.py
@@ -211,10 +211,13 @@ def test_satflow_dataset_local_using_configuration_with_position_encoding_subset
             assert type(x[k]) == torch.Tensor
             assert x[k].dtype == torch.float32
 
+        assert x["pv_yield"].shape == (4, 94, 3, 128)
+
         for k in ["gsp_yield", "gsp_id", "hrv_sat_data"]:
             assert k in y.keys()
             assert type(y[k]) == torch.Tensor
             assert y[k].dtype == torch.float32
+
         # Make sure file isn't deleted!
         assert os.path.exists(os.path.join(DATA_PATH, "nwp/000000.nc"))
 

--- a/tests/test_satflow_dataset.py
+++ b/tests/test_satflow_dataset.py
@@ -211,7 +211,7 @@ def test_satflow_dataset_local_using_configuration_with_position_encoding_subset
             assert type(x[k]) == torch.Tensor
             assert x[k].dtype == torch.float32
 
-        assert x["pv_yield"].shape == (4, 94, 3, 128)
+        assert x["pv_yield"].shape == (4, 93, 3, 128)
 
         for k in ["gsp_yield", "gsp_id", "hrv_sat_data"]:
             assert k in y.keys()

--- a/tests/test_satflow_dataset.py
+++ b/tests/test_satflow_dataset.py
@@ -179,8 +179,8 @@ def test_satflow_dataset_local_using_configuration_with_position_encoding_subset
             add_position_encoding=True,
             add_hrv_satellite_target=True,
             add_satellite_target=False,
-            data_sources_names = ["gsp", "pv", "hrvsatellite"]
-            )
+            data_sources_names=["gsp", "pv", "hrvsatellite"],
+        )
 
         dataloader_config = dict(
             pin_memory=True,
@@ -191,7 +191,7 @@ def test_satflow_dataset_local_using_configuration_with_position_encoding_subset
             # Disable automatic batching because dataset
             # returns complete batches.
             batch_size=None,
-            )
+        )
 
         _ = torch.utils.data.DataLoader(train_dataset, **dataloader_config)
 
@@ -206,7 +206,7 @@ def test_satflow_dataset_local_using_configuration_with_position_encoding_subset
             "hrv_sat_data_query",
             "gsp_yield_query",
             "hrv_sat_data",
-            ]:
+        ]:
             assert k in x.keys()
             assert type(x[k]) == torch.Tensor
             assert x[k].dtype == torch.float32
@@ -217,6 +217,7 @@ def test_satflow_dataset_local_using_configuration_with_position_encoding_subset
             assert y[k].dtype == torch.float32
         # Make sure file isn't deleted!
         assert os.path.exists(os.path.join(DATA_PATH, "nwp/000000.nc"))
+
 
 def test_zero_pv_systems():
     c = Configuration()

--- a/tests/test_satflow_dataset.py
+++ b/tests/test_satflow_dataset.py
@@ -152,6 +152,72 @@ def test_satflow_dataset_local_using_configuration_with_position_encoding():
         assert os.path.exists(os.path.join(DATA_PATH, "nwp/000000.nc"))
 
 
+def test_satflow_dataset_local_using_configuration_with_position_encoding_subset_of_sources():
+    """Test satflow locally"""
+    c = Configuration()
+    c.input_data = InputData.set_all_to_defaults()
+    c.process.batch_size = 4
+    c.input_data.satellite.satellite_image_size_pixels = 24
+    configuration = c
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+
+        f = Batch.fake(configuration=c)
+        f.save_netcdf(batch_i=0, path=Path(tmpdirname))
+
+        DATA_PATH = tmpdirname
+        TEMP_PATH = tmpdirname
+
+        train_dataset = SatFlowDataset(
+            1,
+            DATA_PATH,
+            TEMP_PATH,
+            cloud="local",
+            history_minutes=10,
+            forecast_minutes=10,
+            configuration=configuration,
+            add_position_encoding=True,
+            add_hrv_satellite_target=True,
+            add_satellite_target=False,
+            data_sources_names = ["gsp", "pv", "hrvsatellite"]
+            )
+
+        dataloader_config = dict(
+            pin_memory=True,
+            num_workers=1,
+            prefetch_factor=1,
+            worker_init_fn=worker_init_fn,
+            persistent_workers=True,
+            # Disable automatic batching because dataset
+            # returns complete batches.
+            batch_size=None,
+            )
+
+        _ = torch.utils.data.DataLoader(train_dataset, **dataloader_config)
+
+        train_dataset.per_worker_init(1)
+        t = iter(train_dataset)
+        x, y = next(t)
+
+        for k in [
+            "pv_yield",
+            "pv_system_id",
+            "gsp_id",
+            "hrv_sat_data_query",
+            "gsp_yield_query",
+            "hrv_sat_data",
+            ]:
+            assert k in x.keys()
+            assert type(x[k]) == torch.Tensor
+            assert x[k].dtype == torch.float32
+
+        for k in ["gsp_yield", "gsp_id", "hrv_sat_data"]:
+            assert k in y.keys()
+            assert type(y[k]) == torch.Tensor
+            assert y[k].dtype == torch.float32
+        # Make sure file isn't deleted!
+        assert os.path.exists(os.path.join(DATA_PATH, "nwp/000000.nc"))
+
 def test_zero_pv_systems():
     c = Configuration()
     c.input_data = InputData.set_all_to_defaults()


### PR DESCRIPTION
# Pull Request

## Description

Currently the dataloader loads all the NEtCDF files in the batch before then throwing some of them away, possibly. This wastes time and compute. This PR adds loading only a subset of the NetCDF files if desired.

Companion PR to be merged first: https://github.com/openclimatefix/nowcasting_dataset/pull/510

This PR also:

- [x] Fixes an issue with the PV Yield being in the wrong order and not getting the position encoding
- [ ] 

Fixes #

## How Has This Been Tested?

Unit tests

- [ ] No
- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
