### PR TITLE
Add t0 datetimes to targets for plotting in SatFlowDataset

### DIFF
--- a/nowcasting_dataloader/datasets.py
+++ b/nowcasting_dataloader/datasets.py
@@ -312,6 +312,9 @@ class SatFlowDataset(NetCDFDataset):
                 :, self.current_timestep_index_30 :
             ]
 
+        # Add more metadata for plotting later
+        target["t0_datetime_UTC"] = batch["metadata"]["t0_datetime_UTC"]
+
         if self.add_satellite_target:
             future_sat_data = batch["satellite"]["data"][:, :, self.current_timestep_index :]
             target[SATELLITE_DATA] = future_sat_data


### PR DESCRIPTION
# Pull Request

## Description

Adds t0 datetimes for plotting the predictions

Fixes #

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] No
- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
